### PR TITLE
Make all assemblies CLS compliant, with exceptions

### DIFF
--- a/Optional.Async/Properties/AssemblyInfo.cs
+++ b/Optional.Async/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("73183408-b4b2-41dd-84d5-f4ec972d7048")]

--- a/Optional.Collections/Properties/AssemblyInfo.cs
+++ b/Optional.Collections/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 #if !NETSTANDARD

--- a/Optional.Sandbox/Properties/AssemblyInfo.cs
+++ b/Optional.Sandbox/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a8ca362a-fcb9-4a33-a0ce-a47b50cd14e2")]

--- a/Optional.Tests/Properties/AssemblyInfo.cs
+++ b/Optional.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6b6c332a-7f93-47fe-a409-fceeea047c0c")]

--- a/Optional.Utilities/Parse.cs
+++ b/Optional.Utilities/Parse.cs
@@ -35,6 +35,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into a signed byte.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<sbyte> ToSByte(string s)
         {
             sbyte result;
@@ -45,6 +46,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into a signed byte.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<sbyte> ToSByte(string s, IFormatProvider provider, NumberStyles styles)
         {
             sbyte result;
@@ -75,6 +77,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into an unsigned short.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<ushort> ToUShort(string s)
         {
             ushort result;
@@ -85,6 +88,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into an unsigned short.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<ushort> ToUShort(string s, IFormatProvider provider, NumberStyles styles)
         {
             ushort result;
@@ -115,6 +119,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into an unsigned int.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<uint> ToUInt(string s)
         {
             uint result;
@@ -125,6 +130,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into an unsigned int.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<uint> ToUInt(string s, IFormatProvider provider, NumberStyles styles)
         {
             uint result;
@@ -155,6 +161,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into an unsigned long.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<ulong> ToULong(string s)
         {
             ulong result;
@@ -165,6 +172,7 @@ namespace Optional.Utilities
         /// Tries to parse a string into an unsigned long.
         /// </summary>
         /// <returns>An optional value containing the result if any.</returns>
+        [CLSCompliant(false)]
         public static Option<ulong> ToULong(string s, IFormatProvider provider, NumberStyles styles)
         {
             ulong result;

--- a/Optional.Utilities/Properties/AssemblyInfo.cs
+++ b/Optional.Utilities/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 #if !NETSTANDARD

--- a/Optional/Properties/AssemblyInfo.cs
+++ b/Optional/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly:CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 #if !NETSTANDARD


### PR DESCRIPTION
According to Microsoft, libraries should be marked with
CLSCompliantAttribute:

https://msdn.microsoft.com/en-us/library/ms182156.aspx

I have added this attribute to all assemblies. In some cases, BCL types
that are not CLS compliant necessitate exceptions to this general rule. In
these cases, I've added [CLSCompliant(false)] to the specific methods.

Hopefully this fixes issue #10.