### PR TITLE
Unnecessary to wrap a lambda with a matching lambda

### DIFF
--- a/Optional.Async/AsyncOption.cs
+++ b/Optional.Async/AsyncOption.cs
@@ -115,7 +115,7 @@ namespace Optional.Async
         /// <returns>The existing or alternative value.</returns>
         public Task<T> ValueOr(Func<T> alternativeFactory)
         {
-            return Match(value => value, () => alternativeFactory());
+            return Match(value => value, alternativeFactory);
         }
 
         // TODO: TEST
@@ -126,7 +126,7 @@ namespace Optional.Async
         /// <returns>The existing or alternative value.</returns>
         public Task<T> ValueOr(Func<Task<T>> alternativeFactory)
         {
-            return Match(value => Task.FromResult(value), () => alternativeFactory());
+            return Match(value => Task.FromResult(value), alternativeFactory);
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace Optional.Async
         {
             return InnerTask.FlatMap(option => option
                 .Match(
-                    some: value => mapping(value),
+                    some: mapping,
                     none: () => Task.FromResult(Option.None<TResult>())
                 )).ToAsyncOption();
         }
@@ -553,7 +553,7 @@ namespace Optional.Async
         {
             return InnerTask.FlatMap(option => option
                 .Match(
-                    some: value => mapping(value),
+                    some: mapping,
                     none: exception => Task.FromResult(Option.None<TResult, TException>(exception))
                 )).ToAsyncOption();
         }

--- a/Optional/Option_Either.cs
+++ b/Optional/Option_Either.cs
@@ -384,7 +384,7 @@ namespace Optional
             if (mapping == null) throw new ArgumentNullException(nameof(mapping));
 
             return Match(
-                some: value => mapping(value),
+                some: mapping,
                 none: exception => Option.None<TResult, TException>(exception)
             );
         }

--- a/Optional/Option_Maybe.cs
+++ b/Optional/Option_Maybe.cs
@@ -337,7 +337,7 @@ namespace Optional
             if (mapping == null) throw new ArgumentNullException(nameof(mapping));
 
             return Match(
-                some: value => mapping(value),
+                some: mapping,
                 none: () => Option.None<TResult>()
             );
         }


### PR DESCRIPTION
It seems unnecessary to wrap a lambda in another when they have identical signatures. This PR sends the compatible lambdas straight-through, avoiding the allocation of an unnecessary closure.

Take the case of `Option<T>.FlatMap(Func<T, Option<TResult>>)`:

```c#
        public Option<TResult> FlatMap<TResult>(Func<T, Option<TResult>> mapping)
        {
            if (mapping == null) throw new ArgumentNullException(nameof(mapping));

            return Match(
                some: value => mapping(value),
                none: () => Option.None<TResult>()
            );
        }
```

This generates the IL:

```
.method public hidebysig instance valuetype Optional.Option`1<!!TResult> 
        FlatMap<TResult>(class [System.Runtime]System.Func`2<!T,valuetype Optional.Option`1<!!TResult>> mapping) cil managed
{
  // Code size       82 (0x52)
  .maxstack  4
  .locals init (class Optional.Option`1/'<>c__DisplayClass30_0`1'<!T,!!TResult> V_0)
  IL_0000:  newobj     instance void class Optional.Option`1/'<>c__DisplayClass30_0`1'<!T,!!TResult>::.ctor()
  IL_0005:  stloc.0
  IL_0006:  ldloc.0
  IL_0007:  ldarg.1
  IL_0008:  stfld      class [System.Runtime]System.Func`2<!0,valuetype Optional.Option`1<!1>> class Optional.Option`1/'<>c__DisplayClass30_0`1'<!T,!!TResult>::mapping
  IL_000d:  ldloc.0
  IL_000e:  ldfld      class [System.Runtime]System.Func`2<!0,valuetype Optional.Option`1<!1>> class Optional.Option`1/'<>c__DisplayClass30_0`1'<!T,!!TResult>::mapping
  IL_0013:  brtrue.s   IL_0020
  IL_0015:  ldstr      "mapping"
  IL_001a:  newobj     instance void [System.Runtime]System.ArgumentNullException::.ctor(string)
  IL_001f:  throw
  IL_0020:  ldarg.0
  IL_0021:  ldloc.0
  IL_0022:  ldftn      instance valuetype Optional.Option`1<!1> class Optional.Option`1/'<>c__DisplayClass30_0`1'<!T,!!TResult>::'<FlatMap>b__0'(!0)
  IL_0028:  newobj     instance void class [System.Runtime]System.Func`2<!T,valuetype Optional.Option`1<!!TResult>>::.ctor(object,
                                                                                                                           native int)
  IL_002d:  ldsfld     class [System.Runtime]System.Func`1<valuetype Optional.Option`1<!1>> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<>9__30_1'
  IL_0032:  dup
  IL_0033:  brtrue.s   IL_004c
  IL_0035:  pop
  IL_0036:  ldsfld     class Optional.Option`1/'<>c__30`1'<!0,!1> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<>9'
  IL_003b:  ldftn      instance valuetype Optional.Option`1<!1> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<FlatMap>b__30_1'()
  IL_0041:  newobj     instance void class [System.Runtime]System.Func`1<valuetype Optional.Option`1<!!TResult>>::.ctor(object,
                                                                                                                        native int)
  IL_0046:  dup
  IL_0047:  stsfld     class [System.Runtime]System.Func`1<valuetype Optional.Option`1<!1>> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<>9__30_1'
  IL_004c:  call       instance !!0 valuetype Optional.Option`1<!T>::Match<valuetype Optional.Option`1<!!0>>(class [System.Runtime]System.Func`2<!0,!!0>,
                                                                                                             class [System.Runtime]System.Func`1<!!0>)
  IL_0051:  ret
} // end of method Option`1::FlatMap
```

Changing to:

```c#
        public Option<TResult> FlatMap<TResult>(Func<T, Option<TResult>> mapping)
        {
            if (mapping == null) throw new ArgumentNullException(nameof(mapping));

            return Match(
                some: mapping,
                none: () => Option.None<TResult>()
            );
        }
```

generates less code because the extra closure allocation (IL_0000-IL_0008 and IL_0021-IL_0028 in disassembly above) is gone:

```
.method public hidebysig instance valuetype Optional.Option`1<!!TResult> 
        FlatMap<TResult>(class [System.Runtime]System.Func`2<!T,valuetype Optional.Option`1<!!TResult>> mapping) cil managed
{
  // Code size       63 (0x3f)
  .maxstack  4
  .locals init ([0] bool V_0,
           [1] valuetype Optional.Option`1<!!TResult> V_1)
  IL_0000:  nop
  IL_0001:  ldarg.1
  IL_0002:  ldnull
  IL_0003:  ceq
  IL_0005:  stloc.0
  IL_0006:  ldloc.0
  IL_0007:  brfalse.s  IL_0014
  IL_0009:  ldstr      "mapping"
  IL_000e:  newobj     instance void [System.Runtime]System.ArgumentNullException::.ctor(string)
  IL_0013:  throw
  IL_0014:  ldarg.0
  IL_0015:  ldarg.1
  IL_0016:  ldsfld     class [System.Runtime]System.Func`1<valuetype Optional.Option`1<!1>> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<>9__30_0'
  IL_001b:  dup
  IL_001c:  brtrue.s   IL_0035
  IL_001e:  pop
  IL_001f:  ldsfld     class Optional.Option`1/'<>c__30`1'<!0,!1> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<>9'
  IL_0024:  ldftn      instance valuetype Optional.Option`1<!1> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<FlatMap>b__30_0'()
  IL_002a:  newobj     instance void class [System.Runtime]System.Func`1<valuetype Optional.Option`1<!!TResult>>::.ctor(object,
                                                                                                                        native int)
  IL_002f:  dup
  IL_0030:  stsfld     class [System.Runtime]System.Func`1<valuetype Optional.Option`1<!1>> class Optional.Option`1/'<>c__30`1'<!T,!!TResult>::'<>9__30_0'
  IL_0035:  call       instance !!0 valuetype Optional.Option`1<!T>::Match<valuetype Optional.Option`1<!!0>>(class [System.Runtime]System.Func`2<!0,!!0>,
                                                                                                             class [System.Runtime]System.Func`1<!!0>)
  IL_003a:  stloc.1
  IL_003b:  br.s       IL_003d
  IL_003d:  ldloc.1
  IL_003e:  ret
} // end of method Option`1::FlatMap
```
