### PR TITLE
Extension method to convert an Option<T> to a Nullable<T>

### DIFF
--- a/Optional/Unsafe/OptionUnsafeExtensions.cs
+++ b/Optional/Unsafe/OptionUnsafeExtensions.cs
@@ -110,5 +110,15 @@ namespace Optional.Unsafe
 
             throw new OptionValueMissingException(errorMessageFactory(option.Exception));
         }
+
+        /// <summary>
+        /// Convert the option to a <see cref="Nullable{T}"/> instance
+        /// that is initialzed with some value of <typeparamref name="T"/>
+        /// or <c>null</c> otherwise.
+        /// </summary>
+        /// <param name="option">The specified optional.</param>
+        /// <returns>A <see cref="Nullable{T}"/> that is the result of the conversion.</returns>
+        public static T? ToNullable<T>(this Option<T> option) where T : struct =>
+            option.Map(v => (T?)v).ValueOr(() => null);
     }
 }


### PR DESCRIPTION
This PR helps with #13 when a conversion to `Nullable<T>` is needed.

It also helps with the example presented in issue #17, which can be written as:

```c#
var d = Option.Some(new DateTime(2010, 12, 31));
var s = string.Format(new CultureInfo("de-DE"), "{0:D}", d.ToNullable());
Console.WriteLine(s);
```

instead of:

```c#
var d = Option.Some(new DateTime(2010, 12, 31));
var s = string.Format(new CultureInfo("de-DE"), "{0:D}", d.Match(v => v, () => default(DateTime?)));
Console.WriteLine(s);
```

That is, of course, while #17 is open.

The method being added by this PR is called `ToNullable()` instead of `ValueOrNull()` because you cannot overload on generic type parameter constraints and if `ValueOrNull()` is subsequently added then that would only apply to `Option<T>` where `T` is a reference.