### PR TITLE
Added support for null-reference comparison to avoid NullReferenceExceptions

### DIFF
--- a/Optional.Tests/EitherTests.cs
+++ b/Optional.Tests/EitherTests.cs
@@ -145,6 +145,30 @@ namespace Optional.Tests
         }
 
         [TestMethod]
+        public void Either_Null_Comparison_Doesnt_Throw()
+        {
+            try
+            {
+                var result = (Option.Some<string, string>("val") != null);
+                result = (null != Option.Some<string, string>("val"));
+
+                result = (Option.Some<string, string>("val") == null);
+                result = (null == Option.Some<string, string>("val"));
+
+                Option<string, string> nullOption = null;
+                result = (nullOption != null);
+                result = (null != nullOption);
+
+                result = (nullOption == null);
+                result = (null == nullOption);
+            }
+            catch (NullReferenceException exc)
+            {
+                Assert.Fail("NullReferenceException was thrown.");
+            }
+        }
+
+        [TestMethod]
         public void Either_Hashing()
         {
             Assert.AreEqual(Option.None<string, string>("ex").GetHashCode(), Option.None<string, string>("ex").GetHashCode());

--- a/Optional.Tests/MaybeTests.cs
+++ b/Optional.Tests/MaybeTests.cs
@@ -132,6 +132,26 @@ namespace Optional.Tests
         }
 
         [TestMethod]
+	    public void Maybe_Null_Comparison_Doesnt_Throw() {
+	        try {
+                var result = (Option.Some("val") != null);
+                result = (null != Option.Some("val"));
+
+                result = (Option.Some("val") == null);
+                result = (null == Option.Some("val"));
+
+		        Option<string> nullOption = null;
+                result = (nullOption != null);
+                result = (null != nullOption);
+
+                result = (nullOption == null);
+                result = (null == nullOption);
+            } catch (NullReferenceException exc) {
+		        Assert.Fail("NullReferenceException was thrown.");
+	        }
+	    }
+
+        [TestMethod]
         public void Maybe_Hashing()
         {
             Assert.AreEqual(Option.None<string>().GetHashCode(), Option.None<string>().GetHashCode());

--- a/Optional/Option_Either.cs
+++ b/Optional/Option_Either.cs
@@ -41,6 +41,11 @@ namespace Optional
         /// <returns>A boolean indicating whether or not the optionals are equal.</returns>
         public bool Equals(Option<T, TException> other)
         {
+            //Comparison with null (obj == null), same as !hasValue
+            bool isOtherNull = ReferenceEquals(other, null);
+            if (isOtherNull)
+                return !hasValue;
+
             if (!hasValue && !other.hasValue)
             {
                 return EqualityComparer<TException>.Default.Equals(exception, other.exception);
@@ -66,7 +71,17 @@ namespace Optional
         /// <param name="left">The first optional to compare.</param>
         /// <param name="right">The second optional to compare.</param>
         /// <returns>A boolean indicating whether or not the optionals are equal.</returns>
-        public static bool operator ==(Option<T, TException> left, Option<T, TException> right) => left.Equals(right);
+        public static bool operator ==(Option<T, TException> left, Option<T, TException> right) {
+            //(null == null) is true
+            if (ReferenceEquals(left, null) &&
+	            ReferenceEquals(right, null))
+		        return true;
+
+            if (ReferenceEquals(left, null))
+                return right.Equals(null);
+
+            return left.Equals(right);
+        }
 
         /// <summary>
         /// Determines whether two optionals are unequal.
@@ -74,7 +89,18 @@ namespace Optional
         /// <param name="left">The first optional to compare.</param>
         /// <param name="right">The second optional to compare.</param>
         /// <returns>A boolean indicating whether or not the optionals are unequal.</returns>
-        public static bool operator !=(Option<T, TException> left, Option<T, TException> right) => !left.Equals(right);
+        public static bool operator !=(Option<T, TException> left, Option<T, TException> right) {
+            //(null != null) is false
+            if (ReferenceEquals(left, null) &&
+                    ReferenceEquals(right, null))
+                return false;
+                
+
+            if (ReferenceEquals(left, null))
+                return !right.Equals(null);
+
+            return !left.Equals(right);
+        }
 
         /// <summary>
         /// Generates a hash code for the current optional.

--- a/Optional/Option_Maybe.cs
+++ b/Optional/Option_Maybe.cs
@@ -35,8 +35,12 @@ namespace Optional
         /// </summary>
         /// <param name="other">The optional to compare with the current one.</param>
         /// <returns>A boolean indicating whether or not the optionals are equal.</returns>
-        public bool Equals(Option<T> other)
-        {
+        public bool Equals(Option<T> other) {
+            //Comparison with null (obj == null), same as !hasValue
+	        bool isOtherNull = ReferenceEquals(other, null);
+	        if (isOtherNull)
+		        return !hasValue;
+
             if (!hasValue && !other.hasValue)
             {
                 return true;
@@ -62,7 +66,17 @@ namespace Optional
         /// <param name="left">The first optional to compare.</param>
         /// <param name="right">The second optional to compare.</param>
         /// <returns>A boolean indicating whether or not the optionals are equal.</returns>
-        public static bool operator ==(Option<T> left, Option<T> right) => left.Equals(right);
+        public static bool operator ==(Option<T> left, Option<T> right) {
+            //(null == null) is true
+            if (ReferenceEquals(left, null) &&
+	                ReferenceEquals(right, null))
+		        return true;
+
+	        if (ReferenceEquals(left, null))
+                return right.Equals(null);
+
+            return left.Equals(right);
+        }
 
         /// <summary>
         /// Determines whether two optionals are unequal.
@@ -70,7 +84,18 @@ namespace Optional
         /// <param name="left">The first optional to compare.</param>
         /// <param name="right">The second optional to compare.</param>
         /// <returns>A boolean indicating whether or not the optionals are unequal.</returns>
-        public static bool operator !=(Option<T> left, Option<T> right) => !left.Equals(right);
+        public static bool operator !=(Option<T> left, Option<T> right) {
+            //(null != null) is false
+            if (ReferenceEquals(left, null) &&
+    		        ReferenceEquals(right, null))
+			    return false;
+
+
+            if (ReferenceEquals(left, null))
+                return !right.Equals(null);
+
+            return !left.Equals(right);
+	    }
 
         /// <summary>
         /// Generates a hash code for the current optional.


### PR DESCRIPTION
Added support for null-reference comparison to avoid NullReferenceExceptions when comparing Option with null:

    (null == option) no longer throws an exception
    (null != option) no longer throws an exception
    (option != null) will be treated as Option.hasValue for backwards-compatibility reasons when upgrading code to use Option.