### PR TITLE
Implement IComparable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+*.ncrunchproject
+*.ncrunchsolution
 
 # MightyMoose
 *.mm.*

--- a/src/Optional.Tests/EitherTests.cs
+++ b/src/Optional.Tests/EitherTests.cs
@@ -147,6 +147,49 @@ namespace Optional.Tests
         }
 
         [TestMethod]
+        public void Either_CompareTo()
+        {
+            // Value type comparisons
+            var noneStruct = Option.None<int, string>("none");
+            var someStruct1 = Option.Some<int, string>(1);
+            var someStruct2 = Option.Some<int, string>(2);
+
+            Assert.AreEqual(someStruct1, new[] { someStruct1, someStruct2 }.Min());
+            Assert.AreEqual(noneStruct, new[] { noneStruct, someStruct1 }.Min());
+            Assert.AreEqual(noneStruct, new[] { noneStruct, noneStruct }.Min());
+
+            Assert.AreEqual(someStruct2, new[] { someStruct1, someStruct2 }.Max());
+            Assert.AreEqual(someStruct1, new[] { noneStruct, someStruct1 }.Max());
+            Assert.AreEqual(noneStruct, new[] { noneStruct, noneStruct }.Max());
+
+            // IComparable comparisons
+            var noneComparable = Option.None<string, int>(0);
+            var someComparable1 = Option.Some<string, int>("1");
+            var someComparable2 = Option.Some<string, int>("2");
+
+            Assert.AreEqual(someComparable1, new[] { someComparable1, someComparable2 }.Min());
+            Assert.AreEqual(noneComparable, new[] { noneComparable, someComparable1 }.Min());
+            Assert.AreEqual(noneComparable, new[] { noneComparable, noneComparable }.Min());
+
+            Assert.AreEqual(someComparable2, new[] { someComparable1, someComparable2 }.Max());
+            Assert.AreEqual(someComparable1, new[] { noneComparable, someComparable1 }.Max());
+            Assert.AreEqual(noneComparable, new[] { noneComparable, noneComparable }.Max());
+
+            // Non-IComparable comparisons
+            var noneNotComparable = Option.None<Dictionary<string, string>, string>("none");
+            var someNotComparable1 = Option.Some<Dictionary<string, string>, string>(new Dictionary<string, string>());
+            var someNotComparable2 = Option.Some<Dictionary<string, string>, string>(new Dictionary<string, string>());
+
+            Assert.ThrowsException<ArgumentException>(() => new[] { someNotComparable1, someNotComparable2 }.Min());
+            Assert.AreEqual(noneNotComparable, new[] { noneNotComparable, someNotComparable1 }.Min());
+            Assert.AreEqual(noneNotComparable, new[] { noneNotComparable, noneNotComparable }.Min());
+
+            Assert.ThrowsException<ArgumentException>(() => new[] { someNotComparable1, someNotComparable2 }.Max());
+            Assert.AreEqual(someNotComparable1, new[] { noneNotComparable, someNotComparable1 }.Max());
+            Assert.AreEqual(noneNotComparable, new[] { noneNotComparable, noneNotComparable }.Max());
+        }
+
+        [TestMethod]
         public void Either_Hashing()
         {
             Assert.AreEqual(Option.None<string, string>("ex").GetHashCode(), Option.None<string, string>("ex").GetHashCode());

--- a/src/Optional.Tests/MaybeTests.cs
+++ b/src/Optional.Tests/MaybeTests.cs
@@ -135,6 +135,49 @@ namespace Optional.Tests
         }
 
         [TestMethod]
+        public void Maybe_CompareTo()
+        {
+            // Value type comparisons
+            var noneStruct = Option.None<int>();
+            var someStruct1 = Option.Some<int>(1);
+            var someStruct2 = Option.Some<int>(2);
+
+            Assert.AreEqual(someStruct1, new[] {someStruct1, someStruct2}.Min());
+            Assert.AreEqual(noneStruct, new[] {noneStruct, someStruct1}.Min());
+            Assert.AreEqual(noneStruct, new[] {noneStruct, noneStruct}.Min());
+
+            Assert.AreEqual(someStruct2, new[] {someStruct1, someStruct2}.Max());
+            Assert.AreEqual(someStruct1, new[] {noneStruct, someStruct1}.Max());
+            Assert.AreEqual(noneStruct, new[] {noneStruct, noneStruct}.Max());
+
+            // IComparable comparisons
+            var noneComparable = Option.None<string>();
+            var someComparable1 = Option.Some<string>("1");
+            var someComparable2 = Option.Some<string>("2");
+
+            Assert.AreEqual(someComparable1, new[] {someComparable1, someComparable2}.Min());
+            Assert.AreEqual(noneComparable, new[] {noneComparable, someComparable1}.Min());
+            Assert.AreEqual(noneComparable, new[] {noneComparable, noneComparable}.Min());
+
+            Assert.AreEqual(someComparable2, new[] {someComparable1, someComparable2}.Max());
+            Assert.AreEqual(someComparable1, new[] {noneComparable, someComparable1}.Max());
+            Assert.AreEqual(noneComparable, new[] {noneComparable, noneComparable}.Max());
+
+            // Non-IComparable comparisons
+            var noneNotComparable = Option.None<Dictionary<string, string>>();
+            var someNotComparable1 = Option.Some<Dictionary<string, string>>(new Dictionary<string, string>());
+            var someNotComparable2 = Option.Some<Dictionary<string, string>>(new Dictionary<string, string>());
+
+            Assert.ThrowsException<ArgumentException>(() => new[] {someNotComparable1, someNotComparable2}.Min());
+            Assert.AreEqual(noneNotComparable, new[] {noneNotComparable, someNotComparable1}.Min());
+            Assert.AreEqual(noneNotComparable, new[] {noneNotComparable, noneNotComparable}.Min());
+
+            Assert.ThrowsException<ArgumentException>(() => new[] {someNotComparable1, someNotComparable2}.Max());
+            Assert.AreEqual(someNotComparable1, new[] {noneNotComparable, someNotComparable1}.Max());
+            Assert.AreEqual(noneNotComparable, new[] {noneNotComparable, noneNotComparable}.Max());
+        }
+
+        [TestMethod]
         public void Maybe_Hashing()
         {
             Assert.AreEqual(Option.None<string>().GetHashCode(), Option.None<string>().GetHashCode());

--- a/src/Optional/Option_Either.cs
+++ b/src/Optional/Option_Either.cs
@@ -13,7 +13,7 @@ namespace Optional
 #if !NETSTANDARD10
     [Serializable]
 #endif
-    public struct Option<T, TException> : IEquatable<Option<T, TException>>
+    public struct Option<T, TException> : IEquatable<Option<T, TException>>, IComparable<Option<T, TException>>
     {
         private readonly bool hasValue;
         private readonly T value;
@@ -98,6 +98,39 @@ namespace Optional
             }
 
             return exception.GetHashCode();
+        }
+
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an
+        /// integer that indicates whether the current instance precedes, follows, or occurs in
+        /// the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        /// <returns>A value that indicates the relative order of the objects being compared.</returns>
+        public int CompareTo(Option<T, TException> other)
+        {
+            if (!hasValue && !other.hasValue)
+            {
+                // If both have exceptions, sort by the exceptions
+                return Comparer<TException>.Default.Compare(exception, other.exception);
+            }
+            else if (hasValue && other.hasValue)
+            {
+                // If both have values, sort by the values
+                return Comparer<T>.Default.Compare(value, other.value);
+            }
+
+            // If one has an exception and the other has a value, sort the exceptions before the values
+            // to maintain the ComapresTo contract, which sorts nulls before values
+            if (!hasValue)
+            {
+                return -1;
+            }
+            else
+            {
+                return 1;
+            }
         }
 
         /// <summary>

--- a/src/Optional/Option_Maybe.cs
+++ b/src/Optional/Option_Maybe.cs
@@ -12,7 +12,7 @@ namespace Optional
 #if !NETSTANDARD10
     [Serializable]
 #endif
-    public struct Option<T> : IEquatable<Option<T>>
+    public struct Option<T> : IEquatable<Option<T>>, IComparable<Option<T>>
     {
         private readonly bool hasValue;
         private readonly T value;
@@ -89,6 +89,18 @@ namespace Optional
             }
 
             return 0;
+        }
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an
+        /// integer that indicates whether the current instance precedes, follows, or occurs in
+        /// the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        /// <returns>A value that indicates the relative order of the objects being compared.</returns>
+        public int CompareTo(Option<T> other)
+        {
+            return Comparer<T>.Default.Compare(value, other.value);
         }
 
         /// <summary>


### PR DESCRIPTION
Implement `IComparable<T>` on `Option<T>` and `Option<T, TException>` by delegating to the default
`Comparer` object. This allows the option type to be used natively by methods like `Math.Min()`.

For `Option<T, TException>` there  is one possibly unintuitive outcome: when one Option has an exception and the other does not, the exception always sorts first.

This is done to maintain the contract of `CompareTo`, which sorts `null` before a value. This behavior makes sense in cases like `Option<int, string>`, since `int` and `string` can't be compared anyways, however, it may lead to surprising results in cases where the value and exception type are the same. For example `Option.None<int, int>(1000)` would sort **before** `Option.Some<int, int>(0)`, since `None` is analogous to `null`.

Here's the same example using sort:
```csharp
var items = new[] {Option.Some<int, int>(3), Option.None<int, int>(1), Option.Some<int, int>(-1)};
Array.Sort(items);
// returns: Option.None<int, int>(1), Option.Some<int, int>(-1), Option.Some<int, int>(3)
```

In the case where the exception is being used like a default value, instead you could do:
```csharp
var items = new[] {Option.Some<int, int>(3), Option.None<int, int>(1), Option.Some<int, int>(-1)};
var values = items.Select(option => option.ValueOrException()).ToArray();
Array.Sort(values);
// returns: -1, 1, 3
```
Or if you wanted to keep the elements as options you can implement `IComparer`:
```csharp
public class ValueOrExceptionComparer : IComparer<Option<int, int>>
{
    public int Compare(Option<int, int> x, Option<int, int> y)
    {
        return Comparer<int>.Default.Compare(x.ValueOrException(), y.ValueOrException());
    }
}

var items = new[] {Option.Some<int, int>(3), Option.None<int, int>(1), Option.Some<int, int>(-1)};
Array.Sort(items, new ValueOrExceptionComparer());
// returns: Option.Some<int, int>(-1), Option.None<int, int>(1), Option.Some<int, int>(3)
```