### PR TITLE
Extended the SomeWhen and NoneWhen functionality.

### DIFF
--- a/src/Optional.Tests/Extensions/ExtensionsTests.cs
+++ b/src/Optional.Tests/Extensions/ExtensionsTests.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Optional.Tests.Extensions
+{
+    [TestClass]
+    public class ExtensionsTests
+    {
+        [TestMethod]
+        public void SomeWhen_Exception_Factory_Some()
+        {
+            // Arrange
+            var value = OperationResult.Success();
+
+            // Act
+            var option = value.SomeWhen(
+                x => x.Succeeded,
+                x => x.Errors);
+
+            // Assert
+            Assert.IsTrue(option.HasValue);
+            Assert.IsTrue(option.Exists(x => x.Equals(value)));
+        }
+
+        [TestMethod]
+        public void SomeWhen_Exception_Factory_None()
+        {
+            // Arrange
+            var value = OperationResult.Failure("Error 1", "Error 2");
+
+            // Act
+            var option = value.SomeWhen(
+                x => x.Succeeded,
+                x => x.Errors);
+            
+            // Assert
+            Assert.IsFalse(option.HasValue);
+            AssertContainsErrors(option, value.Errors);
+        }
+
+        [TestMethod]
+        public void NoneWhen_Exception_Factory_Some()
+        {
+            // Arrange
+            var value = OperationResult.Success();
+
+            // Act
+            var option = value.NoneWhen(
+                x => x.Succeeded,
+                x => x.Errors);
+
+            // Assert
+            Assert.IsFalse(option.HasValue);
+            AssertContainsErrors(option, value.Errors);
+        }
+
+        [TestMethod]
+        public void NoneWhen_Exception_Factory_None()
+        {
+            // Arrange
+            var value = OperationResult.Failure("Error 1", "Error 2");
+
+            // Act
+            var option = value.NoneWhen(
+                x => x.Succeeded,
+                x => x.Errors);
+
+            // Assert
+            Assert.IsTrue(option.HasValue);
+            AssertContainsErrors(option, value.Errors);
+        }
+
+        private void AssertContainsErrors(Option<OperationResult, List<string>> option, List<string> errors) =>
+            option.MatchNone(errs => Assert.IsTrue(errs.All(err => errors.Contains(err))));
+
+        private class OperationResult
+        {
+            public bool Succeeded { get; set; }
+
+            public List<string> Errors { get; set; } = new List<string>();
+
+            public static OperationResult Success() => new OperationResult { Succeeded = true };
+
+            public static OperationResult Failure(params string[] errors) => new OperationResult { Succeeded = false, Errors = errors.ToList() };
+        }
+    }
+}

--- a/src/Optional/OptionExtensions.cs
+++ b/src/Optional/OptionExtensions.cs
@@ -65,6 +65,13 @@ namespace Optional
             return predicate(value) ? Option.Some<T, TException>(value) : Option.None<T, TException>(exception);
         }
 
+        public static Option<T, TException> SomeWhen<T, TException>(this T value, Func<T, bool> predicate, Func<T, TException> exceptionFactory)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (exceptionFactory == null) throw new ArgumentNullException(nameof(exceptionFactory));
+            return predicate(value) ? Option.Some<T, TException>(value) : Option.None<T, TException>(exceptionFactory(value));
+        }
+
         /// <summary>
         /// Creates an Option&lt;T&gt; instance from a specified value. 
         /// If the value does not satisfy the given predicate, 
@@ -120,6 +127,13 @@ namespace Optional
         /// <param name="exceptionFactory">A factory function to create an exceptional value.</param>
         /// <returns>An optional containing the specified value.</returns>
         public static Option<T, TException> NoneWhen<T, TException>(this T value, Func<T, bool> predicate, Func<TException> exceptionFactory)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (exceptionFactory == null) throw new ArgumentNullException(nameof(exceptionFactory));
+            return value.SomeWhen(val => !predicate(val), exceptionFactory);
+        }
+
+        public static Option<T, TException> NoneWhen<T, TException>(this T value, Func<T, bool> predicate, Func<T, TException> exceptionFactory)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
             if (exceptionFactory == null) throw new ArgumentNullException(nameof(exceptionFactory));

--- a/src/Optional/OptionExtensions.cs
+++ b/src/Optional/OptionExtensions.cs
@@ -65,6 +65,15 @@ namespace Optional
             return predicate(value) ? Option.Some<T, TException>(value) : Option.None<T, TException>(exception);
         }
 
+        /// <summary>
+        /// Creates an Option&lt;T&gt; instance from a specified value. 
+        /// If the value does not satisfy the given predicate, 
+        /// an empty optional is returned, with a specified exceptional value.
+        /// </summary>
+        /// <param name="value">The value to wrap.</param>
+        /// <param name="predicate">The predicate.</param>
+        /// <param name="exceptionFactory">A factory function to create an exceptional value.</param>
+        /// <returns>An optional containing the specified value.</returns>
         public static Option<T, TException> SomeWhen<T, TException>(this T value, Func<T, bool> predicate, Func<T, TException> exceptionFactory)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
@@ -133,6 +142,15 @@ namespace Optional
             return value.SomeWhen(val => !predicate(val), exceptionFactory);
         }
 
+        /// <summary>
+        /// Creates an Option&lt;T&gt; instance from a specified value. 
+        /// If the value does satisfy the given predicate, 
+        /// an empty optional is returned, with a specified exceptional value.
+        /// </summary>
+        /// <param name="value">The value to wrap.</param>
+        /// <param name="predicate">The predicate.</param>
+        /// <param name="exceptionFactory">A factory function to extract the exception from the value.</param>
+        /// <returns>An optional containing the specified value.</returns>
         public static Option<T, TException> NoneWhen<T, TException>(this T value, Func<T, bool> predicate, Func<T, TException> exceptionFactory)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));


### PR DESCRIPTION
Added a

```C#
SomeWhen<T, TException>(this T value, Func<T, bool> predicate, Func<T, TException> exceptionFactory)
```
and a

```C#
NoneWhen<T, TException>(this T value, Func<T, bool> predicate, Func<TException> exceptionFactory)
```
extension methods and their corresponding tests.

These come really handy when you deal with results such as ASP.NET Identity's IdentityResult.

Example:

```C#
var creationResult = (await UserManager.CreateAsync(user, model.Password))
                .SomeWhen(
                    x => x.Succeeded,
                    x => x.Errors.Select(e => e.Description).ToArray());
```
