### PR TITLE
Add Combine function to maybe type.

### DIFF
--- a/src/Optional.Tests/MaybeTests.cs
+++ b/src/Optional.Tests/MaybeTests.cs
@@ -668,6 +668,50 @@ namespace Optional.Tests
             Assert.AreEqual(some3.ValueOr("-1"), "1");
         }
 
+        [TestMethod]
+        public void Maybe_CombineStrings()
+        {
+            var some1 = Option.Some("a");
+            var some2 = Option.Some("b");
+            var none = Option.None<string>();
+
+            var some1And2 = some1.Combine(some2, StringConcat);
+            var some2And1 = some2.Combine(some1, StringConcat);
+            var some1AndNone = some1.Combine(none, StringConcat);
+            var noneAndSome1 = none.Combine(some1, StringConcat);
+            var noneAndNone = none.Combine(none, StringConcat);
+
+            Assert.AreEqual(some1And2.ValueOr(""), "ab");
+            Assert.AreEqual(some2And1.ValueOr(""), "ba");
+            Assert.AreEqual(some1AndNone.ValueOr(""), "a");
+            Assert.AreEqual(noneAndSome1.ValueOr(""), "a");
+            Assert.IsFalse(noneAndNone.HasValue);
+        }
+
+        private static string StringConcat(string a, string b) => a + b;
+
+        [TestMethod]
+        public void Maybe_CombineInts()
+        {
+            var some1 = Option.Some(3);
+            var some2 = Option.Some(4);
+            var none = Option.None<int>();
+
+            var some1And2 = some1.Combine(some2, IntSum);
+            var some2And1 = some2.Combine(some1, IntSum);
+            var some1AndNone = some1.Combine(none, IntSum);
+            var noneAndSome1 = none.Combine(some1, IntSum);
+            var noneAndNone = none.Combine(none, IntSum);
+
+            Assert.AreEqual(some1And2.ValueOr(-1), 7);
+            Assert.AreEqual(some2And1.ValueOr(-1), 7);
+            Assert.AreEqual(some1AndNone.ValueOr(-1), 3);
+            Assert.AreEqual(noneAndSome1.ValueOr(-1), 3);
+            Assert.IsFalse(noneAndNone.HasValue);
+        }
+
+        private static int IntSum(int a, int b) => a + b;
+
 #if !NETSTANDARD10
         [TestMethod]
         public void Maybe_Serialization()

--- a/src/Optional/Option_Maybe.cs
+++ b/src/Optional/Option_Maybe.cs
@@ -424,5 +424,22 @@ namespace Optional
         /// </summary>
         /// <returns>The filtered optional.</returns>
         public Option<T> NotNull() => hasValue && value == null ? Option.None<T>() : this;
+
+        /// <summary>
+        /// Aggregates this optional with another optional.
+        /// Applies the merge function if both have a value,
+        /// otherwise returns the optional not empty.
+        /// If both are empty, an empty optional is returned.
+        /// </summary>
+        /// <param name="other">The other optional.</param>
+        /// <param name="combine">The merge function.</param>
+        /// <returns>The combined optional.</returns>
+        public Option<T> Combine(Option<T> other, Func<T, T, T> combine)
+        {
+            if (!hasValue) return other;
+            if (!other.hasValue) return this;
+
+            return FlatMap(thisValue => other.Map(otherValue => combine(thisValue, otherValue)));
+        }
     }
 }


### PR DESCRIPTION
Provides a Combine function to merge two optionals (sometimes called "concat" or "append" or "aggregate" in other functional libraries).

[This](https://github.com/lbragaglia/kata-fizzbuzz-csharp/blob/906201bdda38092da74499ef383057618f3c5ddf/ConcatenatingTranslator.cs#L16) is an example of usage in a solution of the FizzBuzz Kata.

Can be used on enumerable of optionals with Aggregate() in this way:
```csharp
listOfStrings.Aggregate((a, b) => a.Combine(b, (x, y) => x + y))
```