### PR TITLE
New async extensions

### DIFF
--- a/src/Optional.Async.Tests/AsyncEitherTests.cs
+++ b/src/Optional.Async.Tests/AsyncEitherTests.cs
@@ -1,10 +1,80 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
 
 namespace Optional.Async.Tests
 {
     [TestClass]
     public class AsyncEitherTests
     {
+        [TestMethod]
+        public async Task AsyncEither_SomeNotNullAsync()
+        {
+            // Arrange
+            var task = Task.FromResult<object>(null);
+            var exception = "A truly exceptional string :)";
+
+            // Act
+            var result = await task.SomeNotNullAsync(exception);
+
+            // Assert
+            var expectedResult = (await task).SomeNotNull(exception);
+
+            result.Should().Be(expectedResult);
+        }
+
+        [TestMethod]
+        public async Task AsyncEither_SomeWhenAsync()
+        {
+            // Arrange
+            var value = ValueGenerator.RandomString();
+            var task = Task.FromResult(value);
+
+            Func<string, bool> predicate = s => s == "This should definitely return false";
+            var error = "Error";
+
+            // Act
+            var result = await task.SomeWhenAsync(predicate, error);
+
+            // Assert
+            var expectedResult = (await task).SomeWhen(predicate, error);
+
+            result.Should().Be(expectedResult);
+        }
+
+        [TestMethod]
+        public async Task AsyncEither_SomeWhenAsync_With_ExceptionFactory()
+        {
+            // Arrange
+            var value = ValueGenerator.RandomString();
+            var task = Task.FromResult(value);
+
+            Func<string, bool> predicate = s => s == "This should definitely return false";
+            Func<string, int> exceptionFactory = _ => 10;
+
+            // Act
+            var result = await task.SomeWhenAsync(predicate, exceptionFactory);
+
+            // Assert
+            var expectedResult = (await task).SomeWhen(predicate, exceptionFactory);
+
+            result.Should().Be(expectedResult);
+        }
+
+        [TestMethod]
+        public async Task AsyncEither_ToAsync()
+        {
+            // Arrange
+            var option = 10.Some<int, string>();
+
+            // Act
+            var result = option.ToAsync();
+
+            // Assert
+            (await result).Should().Be(option);
+        }
+
         [TestMethod]
         public void AsyncEither_MapAsync()
         {

--- a/src/Optional.Async.Tests/AsyncMaybeTests.cs
+++ b/src/Optional.Async.Tests/AsyncMaybeTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Optional.Unsafe;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,89 @@ namespace Optional.Async.Tests
     [TestClass]
     public class AsyncMaybeTests
     {
+        [TestMethod]
+        public async Task AsyncMaybe_ToAsync()
+        {
+            // Arrange
+            var option = 10.Some();
+
+            // Act
+            var result = option.ToAsync();
+
+            // Assert
+            (await result).Should().Be(option);
+        }
+
+        [TestMethod]
+        public async Task AsyncMaybe_FlatMapAsync_To_Exceptional()
+        {
+            // Arrange
+            var option = Option.None<int>();
+            var exceptionalOption = Option.None<int, string>(ValueGenerator.RandomString());
+            var error = "Error";
+
+            // Act
+            var result = await option.FlatMapAsync(_ => Task.FromResult(exceptionalOption), error);
+
+            // Assert
+            var expected = Option.None<int, string>(error);
+
+            result.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public async Task AsyncMaybe_FilterAsync_Should_Return_Exception()
+        {
+            // Arrange
+            var optionTask = ValueGenerator.DelayedSome(10);
+
+            Func<int, Task<bool>> predicate = _ => Task.FromResult(false);
+            var exception = "Error";
+
+            // Act
+            var result = await optionTask.FilterAsync(predicate, exception);
+
+            // Assert
+            var expected = Option.None<int, string>(exception);
+
+            result.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public async Task AsyncMaybe_FilterAsync_Should_Return_Value()
+        {
+            // Arrange
+            var value = 10;
+            var optionTask = ValueGenerator.DelayedSome(value);
+
+            Func<int, Task<bool>> predicate = _ => Task.FromResult(true);
+            var exception = "Error";
+
+            // Act
+            var result = await optionTask.FilterAsync(predicate, exception);
+
+            // Assert
+            var expected = Option.Some<int, string>(value);
+
+            result.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public async Task AsyncMaybe_SomeNotNull()
+        {
+            // Arrange
+            object nullObject = null;
+            var nullTask = Task.FromResult(nullObject);
+
+            // Act
+            var result = await nullTask.SomeNotNullAsync();
+
+            // Assert
+            var expected = nullObject.SomeNotNull();
+
+            result.Should().Be(expected);
+        }
+
         [TestMethod]
         public async Task AsyncMaybe_CanMapAsync()
         {

--- a/src/Optional.Async.Tests/ValueGenerator.cs
+++ b/src/Optional.Async.Tests/ValueGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Optional.Async.Tests
 {
@@ -9,6 +10,10 @@ namespace Optional.Async.Tests
             await Task.Delay(100).ConfigureAwait(false);
             return value;
         }
+
+        public static string RandomString() => Guid.NewGuid().ToString();
+        public static Func<T, Task<TResult>> AsyncOperation<T, TResult>(TResult result) => _ => Task.FromResult(result);
+        public static Func<T, TResult> SynchronousOperation<T, TResult>(TResult result) => _ => result;
 
         public static Task<Option<T>> DelayedSome<T>(T value) => DelayedValue(value.Some());
         public static Task<Option<T, TException>> DelayedSome<T, TException>(T value) => DelayedValue(value.Some<T, TException>());

--- a/src/Optional.Async/OptionTaskExtensions_Maybe.cs
+++ b/src/Optional.Async/OptionTaskExtensions_Maybe.cs
@@ -5,6 +5,30 @@ namespace Optional.Async
 {
     public static partial class OptionTaskExtensions
     {
+        public static async Task<TResult> MatchAsync<T, TResult>(this Task<Option<T>> option, Func<T, Task<TResult>> some, Func<Task<TResult>> none) =>
+            await (await option).Match(some, none);
+
+        public static Task<TResult> MatchAsync<T, TResult>(this Option<T> option, Func<T, Task<TResult>> some, Func<TResult> none) =>
+            option.Match(some, none: () => Task.FromResult(none()));
+
+        public static async Task<Option<T>> SomeNotNullAsync<T>(this Task<T> task) =>
+            (await task).SomeNotNull();
+
+        public static Task MatchSomeAsync<T>(this Option<T> option, Func<T, Task> some) =>
+            Task.Run(() => option.MatchSome(v => some(v)));
+
+        public static Task MatchNoneAsync<T>(this Option<T> option, Func<Task> none) =>
+            Task.Run(() => option.MatchNone(() => none()));
+
+        public static Task<TResult> MatchAsync<T, TResult>(this Option<T> option, Func<T, Task<TResult>> some, Func<Task<TResult>> none) =>
+            option.Match(some, none);
+
+        public static Task MatchAsync<T>(this Option<T> option, Func<T, Task> some, Func<Task> none) =>
+            Task.Run(() => option.Match(some, none));
+
+        public static Task MatchAsync<T>(this Option<T> option, Func<T, Task> some, Action none) =>
+            Task.Run(() => option.Match(v => some(v), none));
+
         public static Task<Option<TResult>> MapAsync<T, TResult>(this Option<T> option, Func<T, Task<TResult>> mapping)
         {
             if (mapping == null) throw new ArgumentNullException(nameof(mapping));

--- a/src/Optional.sln
+++ b/src/Optional.sln
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Optional.Sandbox", "Optiona
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Optional.Samples", "Optional.Samples\Optional.Samples.csproj", "{02A7D729-3C90-45E2-8183-FC10BA760A80}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Optional.Async.Tests", "Optional.Async.Tests\Optional.Async.Tests.csproj", "{89D005BD-46B2-4E79-8267-AAB77C818998}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Optional.Async.Tests", "Optional.Async.Tests\Optional.Async.Tests.csproj", "{89D005BD-46B2-4E79-8267-AAB77C818998}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,7 +34,6 @@ Global
 		{A61CE069-370F-474A-B925-C17B74F9198C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A61CE069-370F-474A-B925-C17B74F9198C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F00BED6E-4808-48EE-B14E-092182080EB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F00BED6E-4808-48EE-B14E-092182080EB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F00BED6E-4808-48EE-B14E-092182080EB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F00BED6E-4808-48EE-B14E-092182080EB3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{12606143-9C9B-4A92-81D5-CEA814AC64AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,7 +45,6 @@ Global
 		{9ADFB283-560D-4FD1-981C-3348BF1DDAF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9ADFB283-560D-4FD1-981C-3348BF1DDAF4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{02A7D729-3C90-45E2-8183-FC10BA760A80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{02A7D729-3C90-45E2-8183-FC10BA760A80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02A7D729-3C90-45E2-8183-FC10BA760A80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02A7D729-3C90-45E2-8183-FC10BA760A80}.Release|Any CPU.Build.0 = Release|Any CPU
 		{89D005BD-46B2-4E79-8267-AAB77C818998}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
A list of the added extensions.

```csharp
Task<Option<T, TException>> SomeNotNullAsync<T, TException>(this Task<T> task, TException exception);

Task<Option<T, TException>> SomeWhenAsync<T, TException>(this Task<T> valueTask, Func<T, bool> predicate, Func<T, TException> exceptionFactory);

Task<Option<T, TException>> SomeWhenAsync<T, TException>(this Task<T> task, Func<T, bool> predicate, TException exception);

Task<Option<T, TException>> ToAsync<T, TException>(this Option<T, TException> option);

Task<Option<T>> ToAsync<T>(this Option<T> option);

Task<Option<TResult, TException>> FlatMapAsync<T, TException, TResult>(this Option<T> option, Func<T, Task<Option<TResult, TException>>> mapping, TException exception);

Task<Option<T, TException>> FilterAsync<T, TException>(this Task<Option<T>> optionTask, Func<T, Task<bool>> predicate, TException exception);

Task<Option<T>> SomeNotNullAsync<T>(this Task<T> task);
```

The tests aren't very exhaustive, but that's what I can do at the moment.

Let me know your thoughts.