### PR TITLE
Add implicit casts from a value to Option types

### DIFF
--- a/src/Optional.Tests/EitherTests.cs
+++ b/src/Optional.Tests/EitherTests.cs
@@ -966,5 +966,23 @@ namespace Optional.Tests
             }
         }
 #endif
+
+        [TestMethod]
+        public void Maybe_CastValueToSome()
+        {
+            Option<int, Exception> some = 1;
+
+            Assert.IsTrue(some.HasValue);
+            Assert.AreEqual(1, some.ValueOr(-1));
+        }
+
+        [TestMethod]
+        public void Maybe_CastNullToSome()
+        {
+            Option<string, Exception> some = null;
+
+            Assert.IsTrue(some.HasValue);
+            Assert.AreEqual(null, some.ValueOr("Wrong"));
+        }
     }
 }

--- a/src/Optional.Tests/MaybeTests.cs
+++ b/src/Optional.Tests/MaybeTests.cs
@@ -694,5 +694,22 @@ namespace Optional.Tests
             }
         }
 #endif
+        [TestMethod]
+        public void Maybe_CastValueToSome()
+        {
+            Option<int> some = 1;
+
+            Assert.IsTrue(some.HasValue);
+            Assert.AreEqual(1, some.ValueOr(-1));
+        }
+
+        [TestMethod]
+        public void Maybe_CastNullToSome()
+        {
+            Option<string> some = null;
+
+            Assert.IsTrue(some.HasValue);
+            Assert.AreEqual(null, some.ValueOr("Wrong"));
+        }
     }
 }

--- a/src/Optional/Option_Either.cs
+++ b/src/Optional/Option_Either.cs
@@ -537,5 +537,11 @@ namespace Optional
             if (exceptionFactory == null) throw new ArgumentNullException(nameof(exceptionFactory));
             return hasValue && value == null ? Option.None<T, TException>(exceptionFactory()) : this;
         }
+
+        /// <summary>
+        /// Implicitly wraps an existing value in an Option&lt;T&gt; instance. 
+        /// </summary>
+        /// <param name="value">The value to be wrapped.</param>
+        public static implicit operator Option<T, TException>(T value) => Option.Some<T, TException>(value);
     }
 }

--- a/src/Optional/Option_Maybe.cs
+++ b/src/Optional/Option_Maybe.cs
@@ -424,5 +424,11 @@ namespace Optional
         /// </summary>
         /// <returns>The filtered optional.</returns>
         public Option<T> NotNull() => hasValue && value == null ? Option.None<T>() : this;
+
+        /// <summary>
+        /// Implicitly wraps an existing value in an Option&lt;T&gt; instance. 
+        /// </summary>
+        /// <param name="value">The value to be wrapped.</param>
+        public static implicit operator Option<T>(T value) => Option.Some(value);
     }
 }


### PR DESCRIPTION
Provides an implicit cast from of any type T to a corresponding Option of T

Useful in scenario like this:
```csharp
Option<int> LovelyFunction()
{
    DoSomething();
    DoSomethingElse();
    return 42;
}
```