### PR TITLE
add Filter method which returns exception based on the unmatched value

### DIFF
--- a/src/Optional.Tests/EitherTests.cs
+++ b/src/Optional.Tests/EitherTests.cs
@@ -843,6 +843,70 @@ namespace Optional.Tests
         }
 
         [TestMethod]
+        public void Either_Filtering_With_Unmatched_Value()
+        {
+            var none = "val".None("ex");
+            var some = "val".Some<string, string>();
+
+            var noneNotVal = none.Filter(x => x != "val", x => $"{x}ex1");
+            var someNotVal = some.Filter(x => x != "val", x => $"{x}ex1");
+            var noneVal = none.Filter(x => x == "val", x => $"{x}ex1");
+            var someVal = some.Filter(x => x == "val", x => { Assert.Fail(); return "ex1"; });
+
+            Assert.IsFalse(noneNotVal.HasValue);
+            Assert.IsFalse(someNotVal.HasValue);
+            Assert.IsFalse(noneVal.HasValue);
+            Assert.IsTrue(someVal.HasValue);
+            Assert.AreEqual(noneNotVal.Match(val => val, ex => ex), "ex");
+            Assert.AreEqual(someNotVal.Match(val => val, ex => ex), "valex1");
+            Assert.AreEqual(noneVal.Match(val => val, ex => ex), "ex");
+            Assert.AreEqual(someVal.Match(val => val, ex => ex), "val");
+
+            var noneFalse = none.Filter(false, () => "valex1");
+            var someFalse = some.Filter(false, () => "valex1");
+            var noneTrue = none.Filter(true, () => "valex1");
+            var someTrue = some.Filter(true, () => { Assert.Fail(); return "valex1"; });
+
+            Assert.IsFalse(noneFalse.HasValue);
+            Assert.IsFalse(someFalse.HasValue);
+            Assert.IsFalse(noneTrue.HasValue);
+            Assert.IsTrue(someTrue.HasValue);
+            Assert.AreEqual(noneFalse.Match(val => val, ex => ex), "ex");
+            Assert.AreEqual(someFalse.Match(val => val, ex => ex), "valex1");
+            Assert.AreEqual(noneTrue.Match(val => val, ex => ex), "ex");
+            Assert.AreEqual(someTrue.Match(val => val, ex => ex), "val");
+
+            var someNull = Option.Some<string, string>(null);
+            Assert.IsTrue(someNull.HasValue);
+            Assert.IsFalse(someNull.NotNull(() => "ex").HasValue);
+            Assert.AreEqual(someNull.NotNull(() => "ex").ValueOrException(), "ex");
+
+            var someNullableNull = Option.Some<int?, int?>(null);
+            Assert.IsTrue(someNullableNull.HasValue);
+            Assert.IsFalse(someNullableNull.NotNull(() => -1).HasValue);
+            Assert.AreEqual(someNullableNull.NotNull(() => -1).ValueOrException(), -1);
+
+            var someStructNull = Option.Some<int, int>(default(int));
+            Assert.IsTrue(someStructNull.HasValue);
+            Assert.IsTrue(someStructNull.NotNull(() => -1).HasValue);
+            Assert.AreEqual(someStructNull.NotNull(() => -1).ValueOrException(), default(int));
+
+            Assert.IsTrue(some.HasValue);
+            Assert.IsTrue(some.NotNull(() => "ex").HasValue);
+            Assert.AreEqual(some.NotNull(() => "ex").ValueOrException(), "val");
+
+            Assert.IsFalse(none.HasValue);
+            Assert.IsFalse(none.NotNull(() => "valex1").HasValue);
+            Assert.AreEqual(none.NotNull(() => "valex1").ValueOrException(), "ex");
+
+            var someNotNull = some.NotNull(() => { Assert.Fail(); return "valex1"; });
+            Assert.IsTrue(someNotNull.HasValue);
+
+            var noneNotNull = none.NotNull(() => { Assert.Fail(); return "valex1"; });
+            Assert.IsFalse(noneNotNull.HasValue);
+        }
+
+        [TestMethod]
         public void Either_Filtering_ExceptionPropagation()
         {
             var none = "val".None("ex");

--- a/src/Optional/Option_Either.cs
+++ b/src/Optional/Option_Either.cs
@@ -520,6 +520,20 @@ namespace Optional
         }
 
         /// <summary>
+        /// Empties an optional, and attaches an exceptional value using the unmatched value,
+        /// if a specified predicate is not satisfied.
+        /// </summary>
+        /// <param name="predicate">The predicate.</param>
+        /// <param name="exceptionFactory">A factory function to create an exceptional value to attach.</param>
+        /// <returns>The filtered optional.</returns>
+        public Option<T, TException> Filter(Func<T, bool> predicate, Func<T, TException> exceptionFactory)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (exceptionFactory == null) throw new ArgumentNullException(nameof(exceptionFactory));
+            return hasValue && !predicate(value) ? Option.None<T, TException>(exceptionFactory(value)) : this;
+        }
+
+        /// <summary>
         /// Empties an optional, and attaches an exceptional value, 
         /// if the value is null.
         /// </summary>


### PR DESCRIPTION
This PR is to resolve issue #69 

It adds a new Filter method to the `Option<T, TException>` class. The method is `public Option<T, TException> Filter(Func<T, bool> predicate, Func<T, TException> exceptionFactory)` and its goal is to allow the propagation of the unmatched value to the exception factory Func thus allowing the value in the optional to be used to create the exception when filtering fails to match.

I appreciate your time in taking a look at this PR.